### PR TITLE
Add tooltips to <Text truncate> elements

### DIFF
--- a/src/components/text/Text.stories.tsx
+++ b/src/components/text/Text.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentMeta } from "@storybook/react";
 
 import { Text } from ".";
 import { config } from "../../theme/config.css";
+import { Icon, Icons } from "../icon";
 
 export default {
   title: "Text",
@@ -40,3 +41,16 @@ export const Button300 = () => <Text size="B300">Typography</Text>;
 export const Label400 = () => <Text size="L400">Label</Text>;
 export const Overline400 = () => <Text size="O400">Typography</Text>;
 export const Caption400 = () => <Text size="C400">{loremIpsum}</Text>;
+export const Truncated = () => (
+  <Text
+    style={{ width: "100px" }}
+    truncateTooltip={{
+      position: "Bottom",
+      align: "Start",
+    }}
+    truncate
+  >
+    <Icon src={Icons.Pencil} size="50" />
+    {loremIpsum}
+  </Text>
+);

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -2,13 +2,65 @@ import React from "react";
 import classNames from "classnames";
 import * as css from "./Text.css";
 import { as } from "../as";
+import { Tooltip, TooltipProvider } from "../tooltip";
+import { Align, Position } from "../util";
 
-export const Text = as<"p", css.TextVariants>(
-  ({ as: AsText = "p", className, size, truncate, align, priority, ...props }, ref) => (
-    <AsText
-      className={classNames(css.Text({ size, truncate, align, priority }), className)}
-      {...props}
-      ref={ref}
-    />
-  )
+export type TruncateTooltipProps = {
+  position?: Position;
+  offset?: number;
+  align?: Align;
+  alignOffset?: number;
+  delay?: number;
+};
+
+export type TextProps = {
+  truncateTooltip?: TruncateTooltipProps | boolean;
+} & css.TextVariants;
+
+export const Text = as<"p", TextProps>(
+  ({ as: AsText = "p", className, size, truncate, align, priority, children, ...props }, ref) => {
+    if (truncate && props.truncateTooltip) {
+      const tooltipProps: TruncateTooltipProps = {
+        delay: 1000,
+      };
+      if (typeof props.truncateTooltip === "object") {
+        const src = props.truncateTooltip as any;
+        const dst = tooltipProps as any;
+        Object.keys(src).forEach((key) => {
+          if (typeof src[key] !== "undefined") dst[key] = src[key];
+        });
+      }
+      return (
+        <TooltipProvider
+          {...tooltipProps}
+          tooltip={
+            <Tooltip>
+              <Text size="T300">{children}</Text>
+            </Tooltip>
+          }
+          ref={ref}
+        >
+          {(subref) => (
+            <AsText
+              className={classNames(css.Text({ size, truncate, align, priority }), className)}
+              {...props}
+              ref={subref}
+            >
+              {children}
+            </AsText>
+          )}
+        </TooltipProvider>
+      );
+    }
+
+    return (
+      <AsText
+        className={classNames(css.Text({ size, truncate, align, priority }), className)}
+        {...props}
+        ref={ref}
+      >
+        {children}
+      </AsText>
+    );
+  }
 );


### PR DESCRIPTION
So that text can be fully read in small spaces anyway.

New `truncateTooltip` property can be used to control how the tooltip looks and if it should be shown at all.

Sample locations how this could look in cinny with slight modifications:

![image](https://github.com/cinnyapp/folds/assets/2035977/aa8f457d-2b14-4f5a-b508-ee590d2b0300)

![image](https://github.com/cinnyapp/folds/assets/2035977/a0f06549-3829-47df-9571-3729451a7c64)

![image](https://github.com/cinnyapp/folds/assets/2035977/941acfe3-6612-4a54-934d-4b3534e9d222)

![image](https://github.com/cinnyapp/folds/assets/2035977/e713687b-50bc-49cc-aaed-ce15fbd39c25)

